### PR TITLE
BugFix: Extended Length File Path names

### DIFF
--- a/Externals/poco/Foundation/src/File_WIN32U.cpp
+++ b/Externals/poco/Foundation/src/File_WIN32U.cpp
@@ -443,6 +443,18 @@ void FileImpl::convertPath(const std::string& utf8Path, std::wstring& utf16Path)
 			}
 		}
 	}
+	else
+	{
+		if (utf16Path.compare(0, 8, L"\\\\?\\UNC\\", 8) == 0)
+		{
+			utf16Path.erase(1, 6);	// leave "\\\\" at beginning
+		}
+		else
+		if (utf16Path.compare(0, 4, L"\\\\?\\", 4) == 0)
+		{
+			utf16Path.erase(0, 4);
+		}
+	}
 }
 
 } // namespace Poco


### PR DESCRIPTION
**Symptom:**  If an explicit `\\?\` or `\\?\UNC\` prefix is given for a file path in the Open dialog, that prefix remains with the file path even if it is not necessary to indicate an _Extended Length File Path_ name. It will even be correctly stored and retrieved from the registry.  Generally this is OK, **however** some context menu actions (such as **Rename**, **Delete**, **Left/Right Shell Menu** and **Open With...**) cannot process _Extended Length File Path_ values (because they are implemented via Shell Extensions, which are limited to file path values with less that 260 characters). Unfortunately, the Shell Extensions reject file path values simply based on the `\\?\` prefix, not the actual length of the value.

**Solution:** Remove the explicit `\\?\` or `\\?\UNC\` prefix characters if they are not actually necessary.

**Note:** The context menu actions noted above will still fail for actual _Extended Length File Path_ values, because Shell Extensions (indeed the entire Windows Shell) cannot handle Extended Length File Path names.