### PR TITLE
Trivial Bugfix: Debugger generates three warnings

### DIFF
--- a/Src/CompareEngines/ByteComparator.cpp
+++ b/Src/CompareEngines/ByteComparator.cpp
@@ -541,5 +541,5 @@ inline void ByteComparator::HandleSide1Eol(char **ptr, const char *end, bool eof
 	*ptr = pbuf;
 }
 
-} //namespace namespace CompareEngines
+} //namespace CompareEngines
 

--- a/Src/OpenView.cpp
+++ b/Src/OpenView.cpp
@@ -120,6 +120,7 @@ COpenView::COpenView()
 	, m_pDropHandler(NULL)
 	, m_dwFlags()
 	, m_bAutoCompleteReady()
+	, m_bReadOnly {false, false, false}
 {
 }
 


### PR DESCRIPTION
**Symptom:** Starting WinMerge with an active Debugger generates three identical warning messages ...
    `... \dlgdata.cpp(254) : AppMsg - Warning: dialog data checkbox value (205) out of range.`

**Solution:** The `m_bReadOnly`array was not being initialized, thus all of the `bool` elements had a value of `0xcd` = 205 when initially given to the three **Read-only** checkboxes on the OpenView dialog.

The array is now properly initialized in the `COpenView::` constructor.

**Also:** An unrelated trivial comment is repaired.