### PR TITLE
OpenDlg: Expose cleaner moving/resizing behavior esp. in non-maximize…

### DIFF
--- a/Src/MainFrm.cpp
+++ b/Src/MainFrm.cpp
@@ -313,6 +313,8 @@ int CMainFrame::OnCreate(LPCREATESTRUCT lpCreateStruct)
 	if (CMDIFrameWnd::OnCreate(lpCreateStruct) == -1)
 		return -1;
 
+	m_wndMDIClient.SubclassWindow(m_hWndMDIClient);
+
 	m_lfDiff = Options::Font::Load(GetOptionsMgr(), OPT_FONT_FILECMP);
 	m_lfDir = Options::Font::Load(GetOptionsMgr(), OPT_FONT_DIRCMP);
 	

--- a/Src/OpenFrm.cpp
+++ b/Src/OpenFrm.cpp
@@ -13,8 +13,10 @@
 IMPLEMENT_DYNCREATE(COpenFrame, CMDIChildWnd)
 
 BEGIN_MESSAGE_MAP(COpenFrame, CMDIChildWnd)
-	//{{AFX_MSG_MAP(CMainFrame)
-	ON_WM_PAINT()
+	//{{AFX_MSG_MAP(COpenFrame)
+	ON_WM_ERASEBKGND()
+	ON_WM_NCHITTEST()
+	ON_WM_WINDOWPOSCHANGING()
 	ON_WM_GETMINMAXINFO()
 	//}}AFX_MSG_MAP
 END_MESSAGE_MAP()
@@ -37,103 +39,50 @@ BOOL COpenFrame::PreCreateWindow(CREATESTRUCT& cs)
 	// TODO: Modify the Window class or styles here by modifying the CREATESTRUCT cs
 	if( !CMDIChildWnd::PreCreateWindow(cs) )
 		return FALSE;
-
+	cs.style |= WS_CLIPCHILDREN;
 	return TRUE;
 }
 
-////////////////
-// Recalculate the layout of the view.
-// Move the view to the center of the window.
-// Paul DiLascia described how to center CFormView in MSJ (Oct. 1996)
-// http://www.microsoft.com/msj/archive/S1F64.aspx
-//
-void COpenFrame::RecalcLayout(BOOL bNotify)
+BOOL COpenFrame::OnEraseBkgnd(CDC* pDC)
 {
-	// First, let MFC recalculate the layout as per the 
-	// normal thing. MFC will figure out where to place 
-	// the view, taking into account which status bars 
-	// are displayed, etc.
-	//
-	CFrameWnd::RecalcLayout(bNotify);   
+	CRect rect;
+	GetClientRect(&rect);
+	pDC->FillSolidRect(&rect, ::GetSysColor(COLOR_APPWORKSPACE));
+	return TRUE;
+}
 
-	CScrollView* pView = (CScrollView*)GetActiveView();
-	if (pView != nullptr) {
-		// Move form view to center of main 
-		// window if it's smaller.
-		//
-		CRect rcNormalView;
-		pView->GetWindowRect(&m_rcNormalView);
-		ScreenToClient(&m_rcNormalView);    // view rect MFC would use
-		CSize sz = pView->GetTotalSize();   // length, width
-		CRect rc = m_rcNormalView;
-		if (rc.Width() > sz.cx)                   // if window > form:
-			rc.left += (rc.Width() -sz.cx) >> 1;   // move over half the extra
-		else
-			rc.left = rc.Width() - sz.cx;
-		if (rc.Height() > sz.cy)                  // ditto for height
-			rc.top  += (rc.Height()-sz.cy) >> 1;   // ...
-		else
-			rc.top = rc.Height() - sz.cy;
-
-		// This actually moves the view window
-		pView->SetWindowPos(nullptr, rc.left, rc.top, sz.cx, sz.cy,
-			SWP_NOACTIVATE|SWP_NOZORDER);
+LRESULT COpenFrame::OnNcHitTest(CPoint point)
+{
+	switch (LRESULT const ht = CMDIChildWnd::OnNcHitTest(point))
+	{
+	case HTTOP:
+	case HTBOTTOM:
+	case HTLEFT:
+	case HTTOPLEFT:
+	case HTBOTTOMLEFT:
+		return HTCAPTION;
+	case HTTOPRIGHT:
+	case HTBOTTOMRIGHT:
+		return HTRIGHT;
+	default:
+		return ht;
 	}
 }
 
-//////////////////
-// Moving the view/form to the center of the main
-// frame window will leave extra white space in upper 
-// left corner. To fix this, need to paint two rectangles.
-// Paul DiLascia described how to center CFormView in MSJ (Oct. 1996)
-// http://www.microsoft.com/msj/archive/S1F64.aspx
-//
-void COpenFrame::OnPaint() 
+void COpenFrame::OnWindowPosChanging(WINDOWPOS* lpwndpos)
 {
-   CView* pView = GetActiveView();
-   if (pView != nullptr) {
-      CPaintDC dc(this);
-
-      // Easier to use HBRUSH than create CBrush here.
-      // Note: be sure to use COLOR_3DFACE to get the
-      // right logical color, in case user has customized it.
-      //
-      HBRUSH hOldBrush = (HBRUSH)::SelectObject(dc.m_hDC, 
-         GetSysColorBrush(COLOR_APPWORKSPACE));
-
-	  CRect rc, rcFrame;
-	  GetClientRect(&rcFrame);
-	  rc = rcFrame;
-
-      CRect rcView;                    // actual view pos (we moved it)
-      pView->GetWindowRect(&rcView);   // ...
-      ScreenToClient(&rcView);         // ...
-
-      // paint horz rectangle along top edge
-      rc.bottom = rcView.top;
-      dc.PatBlt(rc.left,rc.top,rc.Width(),rc.Height(),PATCOPY);
-
-      // paint vert rectangle along left side
-      rc.bottom = rcView.bottom;
-      rc.right  = rcView.left;
-      dc.PatBlt(rc.left,rc.top,rc.Width(),rc.Height(),PATCOPY);
-
-      // paint horz rectangle along right edge
-      rc.left = rcView.left + rcView.Width();
-      rc.right = rcFrame.right;
-      rc.bottom = rcFrame.bottom;
-      dc.PatBlt(rc.left,rc.top,rc.Width(),rc.Height(),PATCOPY);
-
-      // paint horz rectangle along bottom edge
-      rc.left = rcFrame.left;
-      rc.right = rcFrame.right;
-      rc.top = rcView.top + rcView.Height();
-      rc.bottom = rcFrame.bottom;
-      dc.PatBlt(rc.left,rc.top,rc.Width(),rc.Height(),PATCOPY);
-
-      ::SelectObject(dc.m_hDC, hOldBrush);
-   }
-   CMDIChildWnd::OnPaint();
+	// Retain frame sizes during tile operations (tolerate overlapping)
+	if ((lpwndpos->flags & (SWP_NOSIZE | SWP_NOOWNERZORDER)) == 0 && !IsZoomed())
+	{
+		if (CScrollView *const pView = static_cast<CScrollView*>(GetActiveView()))
+		{
+			CRect rc;
+			pView->GetWindowRect(&rc);
+			CalcWindowRect(&rc, CWnd::adjustOutside);
+			lpwndpos->cx = rc.Width();
+			lpwndpos->cy = rc.Height();
+		}
+	}
 }
 
 void COpenFrame::OnGetMinMaxInfo(MINMAXINFO* lpMMI)
@@ -154,6 +103,19 @@ void COpenFrame::ActivateFrame(int nCmdShow)
 		nCmdShow = SW_SHOWMAXIMIZED;
 	}
 	CMDIChildWnd::ActivateFrame(nCmdShow);
+	if (CView *const pView = GetActiveView())
+	{
+		WINDOWPLACEMENT wp;
+		wp.length = sizeof wp;
+		GetWindowPlacement(&wp);
+		CRect rc;
+		pView->GetWindowRect(&rc);
+		CalcWindowRect(&rc, CWnd::adjustOutside);
+		wp.rcNormalPosition.right = wp.rcNormalPosition.left + rc.Width();
+		wp.rcNormalPosition.bottom = wp.rcNormalPosition.top + rc.Height();
+		SetWindowPlacement(&wp);
+		pView->ShowWindow(SW_SHOW);
+	}
 }
 
 /**

--- a/Src/OpenFrm.h
+++ b/Src/OpenFrm.h
@@ -14,9 +14,6 @@ public:
 // Attributes
 public:
 
-protected:
-	CRect m_rcNormalView;   // rectangle for normal (MFC) view pos
-
 // Operations
 public:
 	void UpdateResources();
@@ -29,7 +26,6 @@ public:
 	virtual BOOL PreCreateWindow(CREATESTRUCT& cs);
 	virtual void ActivateFrame(int nCmdShow = -1);
 	virtual BOOL DestroyWindow();
-	virtual void RecalcLayout(BOOL bNotify = TRUE);
 	protected:
 	//}}AFX_VIRTUAL
 
@@ -40,7 +36,9 @@ public:
 // Generated message map functions
 protected:
 	//{{AFX_MSG(COpenFrame)
-	afx_msg void OnPaint(); // override required to paint rectangles.
+	afx_msg BOOL OnEraseBkgnd(CDC* pDC);
+	afx_msg LRESULT OnNcHitTest(CPoint point);
+	afx_msg void OnWindowPosChanging(WINDOWPOS* lpwndpos);
 	afx_msg void OnGetMinMaxInfo(MINMAXINFO* lpMMI);
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()

--- a/Src/OpenView.h
+++ b/Src/OpenView.h
@@ -88,7 +88,6 @@ private:
 	String m_strBrowsePath[3]; /**< Left/middle/right path from browse dialog. */
 	CWinThread *m_pUpdateButtonStatusThread;
 	CPicture m_picture; /**< Image loader/viewer for logo image */
-	CRectTracker m_rectTracker;
 	CSize m_sizeOrig;
 	prdlg::CMoveConstraint m_constraint;
 	CFont m_fontSwapButton;
@@ -149,10 +148,10 @@ protected:
 	afx_msg void OnDropFiles(const std::vector<String>& files);
 	afx_msg LRESULT OnUpdateStatus(WPARAM wParam, LPARAM lParam);
 	afx_msg void OnPaint();
-	afx_msg void OnLButtonDown(UINT nFlags, CPoint point);
 	afx_msg void OnLButtonUp(UINT nFlags, CPoint point);
 	afx_msg void OnMouseMove(UINT nFlags, CPoint point);
-	afx_msg BOOL OnSetCursor(CWnd* pWnd, UINT nHitTest, UINT message);
+	afx_msg LRESULT OnNcHitTest(CPoint point);
+	afx_msg void OnWindowPosChanging(WINDOWPOS* lpwndpos);
 	afx_msg void OnWindowPosChanged(WINDOWPOS* lpwndpos);
 	afx_msg void OnDestroy();
 	//}}AFX_MSG


### PR DESCRIPTION
…d state

The proposed change removes the option to move the OpenView window around inside its otherwise empty parent frame, but rather keeps it centered all the time. To retain symmetry, resizing the window by dragging the grip takes effect at both ends.

The changes in MainFrm.* are merely to reduce flicker while the MDI client window messes with its child frames, and can be considered and applied independently.