### PR TITLE
Favor PathContext::GetSize() over PathContext::size()

### DIFF
--- a/Src/DirActions.cpp
+++ b/Src/DirActions.cpp
@@ -294,7 +294,7 @@ DIFFITEM *FindItemFromPaths(const CDiffContext& ctxt, const PathContext& paths)
 {
 	int nBuffer;
 	String file[3], path[3], base;
-	for (nBuffer = 0; nBuffer < static_cast<int>(paths.size()); ++nBuffer)
+	for (nBuffer = 0; nBuffer < paths.GetSize(); ++nBuffer)
 	{
 		String p = paths[nBuffer];
 		file[nBuffer] = paths::FindFileName(p);
@@ -312,11 +312,11 @@ DIFFITEM *FindItemFromPaths(const CDiffContext& ctxt, const PathContext& paths)
 	}
 
 	// Filenames must be identical
-	if (static_cast<size_t>(std::count(file, file + paths.size(), file[0])) < paths.size())
+	if (std::count(file, file + paths.GetSize(), file[0]) < paths.GetSize())
 		return 0;
 
 	DIFFITEM *pos = ctxt.GetFirstDiffPosition();
-	if (paths.size() == 2)
+	if (paths.GetSize() == 2)
 	{
 		while (DIFFITEM *currentPos = pos) // Save our current pos before getting next
 		{
@@ -1422,7 +1422,7 @@ CheckAllowUpwardDirectory(const CDiffContext& ctxt, const CTempPathContext *pTem
 			}
 			for (int i = 0; i < static_cast<int>(path.size()); ++i)
 				pathsParent[i] = pTempPathContext->m_strDisplayRoot[i];
-			if (pathsParent.size() < 3)
+			if (pathsParent.GetSize() < 3)
 			{
 				if (!ctxt.m_piFilterGlobal->includeFile(pathsParent[0], pathsParent[1]))
 					return AllowUpwardDirectory::Never;

--- a/Src/DirDoc.cpp
+++ b/Src/DirDoc.cpp
@@ -505,14 +505,14 @@ void CDirDoc::UpdateChangedItem(const PathContext &paths,
 	if (!pos)
 	{
 		PathContext pathsSwapped(paths);
-		std::swap(pathsSwapped[0], pathsSwapped[static_cast<int>(pathsSwapped.size() - 1)]);
+		std::swap(pathsSwapped[0], pathsSwapped[pathsSwapped.GetSize() - 1]);
 		pos = FindItemFromPaths(*m_pCtxt, pathsSwapped);
-		if (!pos && paths.size() > 2)
+		if (!pos && paths.GetSize() > 2)
 		{
 			pathsSwapped = paths;
 			std::swap(pathsSwapped[0], pathsSwapped[1]);
 			pos = FindItemFromPaths(*m_pCtxt, pathsSwapped);
-			if (!pos && paths.size() > 2)
+			if (!pos && paths.GetSize() > 2)
 			{
 				pathsSwapped = paths;
 				std::swap(pathsSwapped[1], pathsSwapped[2]);

--- a/Src/DirView.cpp
+++ b/Src/DirView.cpp
@@ -1424,10 +1424,10 @@ void CDirView::OpenSelection(SELECTIONTYPE selectionType /*= SELECTIONTYPE_NORMA
 		FileLocation fileloc[3];
 		String strDesc[3];
 		const String sUntitled[] = { _("Untitled left"), paths.GetSize() < 3 ? _("Untitled right") : _("untitled middle"), _("Untitled right") };
-		for (size_t i = 0; i < paths.size(); ++i)
+		for (int i = 0; i < paths.GetSize(); ++i)
 		{
 			if (!pdi[0]->diffcode.exists(i) &&
-				std::count(pdi, pdi + paths.size(), pdi[0]) == static_cast<ptrdiff_t>(paths.size()))
+				std::count(pdi, pdi + paths.GetSize(), pdi[0]) == paths.GetSize())
 				strDesc[i] = sUntitled[i];
 			else
 				fileloc[i].setPath(paths[i]);

--- a/Src/MainFrm.cpp
+++ b/Src/MainFrm.cpp
@@ -1906,7 +1906,7 @@ void CMainFrame::OnSaveProject()
 	{
 		CMergeDoc * pMergeDoc = static_cast<CMergeDoc *>(pFrame->GetActiveDocument());
 		pOpenDoc->m_files = pMergeDoc->m_filePaths;
-		for (size_t pane = 0; pane < pOpenDoc->m_files.size(); ++pane)
+		for (int pane = 0; pane < pOpenDoc->m_files.GetSize(); ++pane)
 			pOpenDoc->m_dwFlags[pane] = FFILEOPEN_PROJECT | (pMergeDoc->m_ptBuf[pane]->GetReadOnly() ? FFILEOPEN_PROJECT : 0);
 		pOpenDoc->m_bRecurse = GetOptionsMgr()->GetBool(OPT_CMP_INCLUDE_SUBDIRS);
 		pOpenDoc->m_strExt = theApp.m_pGlobalFileFilter->GetFilterNameOrMask();

--- a/Src/Merge.cpp
+++ b/Src/Merge.cpp
@@ -1128,7 +1128,7 @@ bool CMergeApp::LoadAndOpenProjectFile(const String& sProject, const String& sRe
 	for (auto& projItem : project.Items())
 	{
 		projItem.GetPaths(tFiles, bRecursive);
-		for (size_t i = 0; i < tFiles.size(); ++i)
+		for (int i = 0; i < tFiles.GetSize(); ++i)
 		{
 			if (!paths::IsPathAbsolute(tFiles[i]))
 				tFiles[i] = paths::ConcatPath(paths::GetParentPath(sProject), tFiles[i]);

--- a/Src/OpenView.cpp
+++ b/Src/OpenView.cpp
@@ -686,7 +686,7 @@ void COpenView::OnLoadProject()
 	ProjectFileItem& projItem = *project.Items().begin();
 	projItem.GetPaths(paths, m_bRecurse);
 	projItem.GetLeftReadOnly();
-	if (paths.size() < 3)
+	if (paths.GetSize() < 3)
 	{
 		m_strPath[0] = paths[0];
 		m_strPath[1] = paths[1];

--- a/Src/PathContext.cpp
+++ b/Src/PathContext.cpp
@@ -272,9 +272,3 @@ PathContextIterator PathContext::end() const
 {
 	return PathContextIterator();
 }
-
-size_t PathContext::size() const
-{
-	return m_nFiles;
-}
-

--- a/Src/PathContext.h
+++ b/Src/PathContext.h
@@ -69,7 +69,6 @@ public:
 
 	const_iterator begin() const;
 	const_iterator end() const;
-	size_t size() const;
 private:
 	int m_nFiles;
 	PathInfo m_path[3]; /**< First, second, third path (left path at start) */


### PR DESCRIPTION
As a side effect, this fixes a few warnings and saves a few typecasts which presumably existed to fix a few warnings.