### PR TITLE
Consolidate FolderCmp (2)

### DIFF
--- a/Src/DirScan.cpp
+++ b/Src/DirScan.cpp
@@ -48,7 +48,7 @@ using Poco::Environment;
 using Poco::Stopwatch;
 
 // Static functions (ie, functions only used locally)
-void CompareDiffItem(DIFFITEM &di, CDiffContext *pCtxt);
+static void CompareDiffItem(DIFFITEM &di, CDiffContext *pCtxt);
 static void StoreDiffData(DIFFITEM &di, CDiffContext *pCtxt,
 		const FolderCmp *pCmpData);
 static DIFFITEM *AddToList(const String &sLeftDir, const String &sRightDir, const DirItem *lent, const DirItem *rent,
@@ -803,7 +803,7 @@ static void UpdateDiffItem(DIFFITEM &di, bool & bExists, CDiffContext *pCtxt)
  * @todo For date compare, maybe we should use creation date if modification
  * date is missing?
  */
-void CompareDiffItem(DIFFITEM &di, CDiffContext * pCtxt)
+static void CompareDiffItem(DIFFITEM &di, CDiffContext * pCtxt)
 {
 	int nDirs = pCtxt->GetCompareDirs();
 	// Clear rescan-request flag (not set by all codepaths)
@@ -824,8 +824,8 @@ void CompareDiffItem(DIFFITEM &di, CDiffContext * pCtxt)
 			)
 		{
 			di.diffcode.diffcode |= DIFFCODE::INCLUDED;
-			FolderCmp folderCmp;
-			di.diffcode.diffcode |= folderCmp.prepAndCompareFiles(pCtxt, di);
+			FolderCmp folderCmp(pCtxt);
+			di.diffcode.diffcode |= folderCmp.prepAndCompareFiles(di);
 			StoreDiffData(di, pCtxt, &folderCmp);
 		}
 		else

--- a/Src/FolderCmp.h
+++ b/Src/FolderCmp.h
@@ -38,11 +38,11 @@ struct PluginsContext
 class FolderCmp
 {
 public:
-	FolderCmp();
+	explicit FolderCmp(CDiffContext *pCtxt);
 	~FolderCmp();
-	bool RunPlugins(CDiffContext * pCtxt, PluginsContext * plugCtxt, String &errStr);
+	bool RunPlugins(PluginsContext * plugCtxt, String &errStr);
 	void CleanupAfterPlugins(PluginsContext *plugCtxt);
-	int prepAndCompareFiles(CDiffContext * pCtxt, DIFFITEM &di);
+	int prepAndCompareFiles(DIFFITEM &di);
 
 	int m_ndiffs;
 	int m_ntrivialdiffs;
@@ -50,6 +50,7 @@ public:
 	DiffFileData m_diffFileData;
 
 private:
+	CDiffContext *const m_pCtxt;
 	std::unique_ptr<CompareEngines::DiffUtils> m_pDiffUtilsEngine;
 	std::unique_ptr<CompareEngines::ByteCompare> m_pByteCompare;
 	std::unique_ptr<CompareEngines::BinaryCompare> m_pBinaryCompare;

--- a/Src/HexMergeDoc.cpp
+++ b/Src/HexMergeDoc.cpp
@@ -73,8 +73,8 @@ static void UpdateDiffItem(int nBuffers, DIFFITEM &di, CDiffContext *pCtxt)
 	// Clear flags
 	di.diffcode.diffcode &= ~(DIFFCODE::TEXTFLAGS | DIFFCODE::COMPAREFLAGS | DIFFCODE::COMPAREFLAGS3WAY);
 	// Really compare
-	FolderCmp folderCmp;
-	di.diffcode.diffcode |= folderCmp.prepAndCompareFiles(pCtxt, di);
+	FolderCmp folderCmp(pCtxt);
+	di.diffcode.diffcode |= folderCmp.prepAndCompareFiles(di);
 }
 
 /**


### PR DESCRIPTION
Store pointer to CDiffContext as a member in FolderCmp.
Next planned step is to have the folder compare threads create a reusable FolderCmp instance in advance rather than repeatedly create dedicated ones for every single file comparison.