### PR TITLE
Consolidate FolderCmp (3)

### DIFF
--- a/Src/DirScan.cpp
+++ b/Src/DirScan.cpp
@@ -27,7 +27,6 @@
 #include "FolderCmp.h"
 #include "FileFilterHelper.h"
 #include "IAbortable.h"
-#include "FolderCmp.h"
 #include "DirItem.h"
 #include "DirTravel.h"
 #include "paths.h"
@@ -48,9 +47,7 @@ using Poco::Environment;
 using Poco::Stopwatch;
 
 // Static functions (ie, functions only used locally)
-static void CompareDiffItem(DIFFITEM &di, CDiffContext *pCtxt);
-static void StoreDiffData(DIFFITEM &di, CDiffContext *pCtxt,
-		const FolderCmp *pCmpData);
+static void CompareDiffItem(FolderCmp &fc, DIFFITEM &di);
 static DIFFITEM *AddToList(const String &sLeftDir, const String &sRightDir, const DirItem *lent, const DirItem *rent,
 	unsigned code, DiffFuncStruct *myStruct, DIFFITEM *parent);
 static DIFFITEM *AddToList(const String &sDir1, const String &sDir2, const String &sDir3, const DirItem *ent1, const DirItem *ent2, const DirItem *ent3,
@@ -86,6 +83,7 @@ public:
 
 	void run()
 	{
+		FolderCmp fc(m_pCtxt);
 		// keep the scripts alive during the Rescan
 		// when we exit the thread, we delete this and release the scripts
 		CAssureScriptsForThread scriptsForRescan;
@@ -97,7 +95,7 @@ public:
 			if (pWorkNf != nullptr) {
 				m_pCtxt->m_pCompareStats->BeginCompare(&pWorkNf->data(), m_id);
 				if (!m_pCtxt->ShouldAbort())
-					CompareDiffItem(pWorkNf->data(), m_pCtxt);
+					CompareDiffItem(fc, pWorkNf->data());
 				pWorkNf->queueResult().enqueueNotification(new WorkCompletedNotification(pWorkNf->data()));
 			}
 			pNf = m_queue.waitDequeueNotification();
@@ -609,6 +607,7 @@ static int CompareItems(NotificationQueue& queue, DiffFuncStruct *myStruct, DIFF
 static int CompareRequestedItems(DiffFuncStruct *myStruct, DIFFITEM *parentdiffpos)
 {
 	CDiffContext *pCtxt = myStruct->context;
+	FolderCmp fc(pCtxt);
 	int res = 0;
 	bool bCompareFailure = false;
 	if (parentdiffpos == nullptr)
@@ -655,7 +654,7 @@ static int CompareRequestedItems(DiffFuncStruct *myStruct, DIFFITEM *parentdiffp
 		{
 			if (di.diffcode.isScanNeeded())
 			{
-				CompareDiffItem(di, pCtxt); 
+				CompareDiffItem(fc, di);
 				if (di.diffcode.isResultError()) { 
 					DIFFITEM *diParent = di.GetParentLink();
 					assert(diParent != nullptr);
@@ -803,8 +802,9 @@ static void UpdateDiffItem(DIFFITEM &di, bool & bExists, CDiffContext *pCtxt)
  * @todo For date compare, maybe we should use creation date if modification
  * date is missing?
  */
-static void CompareDiffItem(DIFFITEM &di, CDiffContext * pCtxt)
+static void CompareDiffItem(FolderCmp &fc, DIFFITEM &di)
 {
+	CDiffContext *const pCtxt = fc.m_pCtxt;
 	int nDirs = pCtxt->GetCompareDirs();
 	// Clear rescan-request flag (not set by all codepaths)
 	di.diffcode.diffcode &= ~DIFFCODE::NEEDSCAN;
@@ -813,7 +813,6 @@ static void CompareDiffItem(DIFFITEM &di, CDiffContext * pCtxt)
 	{
 		// We don't actually 'compare' directories, just add non-ignored
 		// directories to list.
-		StoreDiffData(di, pCtxt, nullptr);
 	}
 	else
 	{
@@ -824,45 +823,26 @@ static void CompareDiffItem(DIFFITEM &di, CDiffContext * pCtxt)
 			)
 		{
 			di.diffcode.diffcode |= DIFFCODE::INCLUDED;
-			FolderCmp folderCmp(pCtxt);
-			di.diffcode.diffcode |= folderCmp.prepAndCompareFiles(di);
-			StoreDiffData(di, pCtxt, &folderCmp);
+			di.diffcode.diffcode |= fc.prepAndCompareFiles(di);
+			di.nsdiffs = fc.m_ndiffs;
+			di.nidiffs = fc.m_ntrivialdiffs;
+
+			for (int i = 0; i < nDirs; ++i)
+			{
+				// Set text statistics
+				if (di.diffcode.exists(i))
+				{
+					di.diffFileInfo[i].m_textStats = fc.m_diffFileData.m_textStats[i];
+					di.diffFileInfo[i].encoding = fc.m_diffFileData.m_FileLocation[i].encoding;
+				}
+			}
 		}
 		else
 		{
 			di.diffcode.diffcode |= DIFFCODE::SKIPPED;
-			StoreDiffData(di, pCtxt, nullptr);
 		}
 	}
-}
-
-/**
- * @brief Send one file or directory result back through the diff context.
- * @param [in] di Data to store.
- * @param [in] pCtxt Compare context.
- * @param [in] pCmpData Folder compare data.
- */
-static void StoreDiffData(DIFFITEM &di, CDiffContext * pCtxt,
-		const FolderCmp * pCmpData)
-{
-	if (pCmpData != nullptr)
-	{
-		di.nsdiffs = pCmpData->m_ndiffs;
-		di.nidiffs = pCmpData->m_ntrivialdiffs;
-
-		for (int i = 0; i < pCtxt->GetCompareDirs(); ++i)
-		{
-			// Set text statistics
-			if (di.diffcode.exists(i))
-			{
-				di.diffFileInfo[i].m_textStats = pCmpData->m_diffFileData.m_textStats[i];
-				di.diffFileInfo[i].encoding = pCmpData->m_diffFileData.m_FileLocation[i].encoding;
-			}
-		}
-	}
-
 	pCtxt->m_pCompareStats->AddItem(di.diffcode.diffcode);
-	//pCtxt->AddDiff(di);
 }
 
 /**

--- a/Src/FolderCmp.h
+++ b/Src/FolderCmp.h
@@ -48,9 +48,9 @@ public:
 	int m_ntrivialdiffs;
 
 	DiffFileData m_diffFileData;
+	CDiffContext *const m_pCtxt;
 
 private:
-	CDiffContext *const m_pCtxt;
 	std::unique_ptr<CompareEngines::DiffUtils> m_pDiffUtilsEngine;
 	std::unique_ptr<CompareEngines::ByteCompare> m_pByteCompare;
 	std::unique_ptr<CompareEngines::BinaryCompare> m_pBinaryCompare;


### PR DESCRIPTION
Have the folder compare threads create a reusable FolderCmp instance in advance rather than repeatedly create dedicated ones for every single file comparison.